### PR TITLE
there is no 'SQLAlchemy' module; use 'sqlalchemy'

### DIFF
--- a/relengapi/blueprints/mapper.py
+++ b/relengapi/blueprints/mapper.py
@@ -6,10 +6,10 @@ import logging
 import re
 import time
 import calendar
-import SQLAlchemy as sa
+import sqlalchemy as sa
 import dateutil.parser
-from SQLAlchemy import orm
-from SQLAlchemy.orm.exc import NoResultFound, MultipleResultsFound
+from sqlalchemy import orm
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from relengapi import db
 from flask import Blueprint
 from flask import g


### PR DESCRIPTION
These were capitalized in 32a6db06, probably just as an overly-broad search-and-replace?
